### PR TITLE
1.0.1+1.20.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 "Component Viewer" is a mod for Minecraft Java Edition that adds functionality to view components on item stacks. If the component value is extensively large, overflowing the screen width or height, it is recommended to use a mod like [Tooltip Scroll](https://modrinth.com/mod/tooltip-scroll) or similar mods.
 
 ## ✨ Features
-- Client-side only
+- Client-side only.
 - Displays all components of an item stack in the tooltips.
 - Components are sorted in alphabetical order.
 - Nicely formatted component values.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@
 
 ![Entity Data](images/entity_data.webp?raw=true)
 
+## 🌍 Languages
+"Component Viewer" only supports **English**. Additional languages can be added using custom resourcepacks with language files. You can find language file templates [here](https://github.com/fixyldev/ComponentViewer/tree/main/assets/lang).
+
 ## 🔍 Useful Resources
 - 🐛 [**Issues**](https://github.com/fixyldev/ComponentViewer/issues): For reporting bugs or suggesting features.
 - 📝 [**Changelog**](https://modrinth.com/mod/component-viewer/changelog): Keep track of all notable changes made to the mod.

--- a/assets/lang/template_1.0.0.json
+++ b/assets/lang/template_1.0.0.json
@@ -1,0 +1,5 @@
+{
+    "componentviewer.tooltips.components.empty": "No Components",
+    "componentviewer.tooltips.components.header": "Components:",
+    "componentviewer.tooltips.components.value": "Value:"
+}

--- a/assets/lang/template_1.0.1.json
+++ b/assets/lang/template_1.0.1.json
@@ -1,0 +1,6 @@
+{
+    "componentviewer.tooltips.components.empty": "No Components",
+    "componentviewer.tooltips.components.header": "Components:",
+    "componentviewer.tooltips.components.value": "Value:",
+    "componentviewer.tooltips.formatter.error": "A formatting error occurred: Displaying non-formatted component value."
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.6+build.1
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.0.0+1.20.6
+mod_version=1.0.1+1.20.6
 maven_group=dev.fixyl.componentviewer
 archives_base_name=componentviewer
 

--- a/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
@@ -52,7 +52,7 @@ public class ComponentFormatter {
 
     public ComponentFormatter(int indentSize, int preCacheIndentLevel) {
 		if (indentSize < 0)
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(String.format("Invalid 'indentSize' argument being '%s' when constructing '%s' object.", indentSize, this.getClass().getName()));
 
         this.indentSize = indentSize;
 
@@ -75,7 +75,7 @@ public class ComponentFormatter {
 
 	public void preCacheIndent(int preCacheIndentLevel) {
 		if (preCacheIndentLevel < 0)
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(String.format("Invalid 'preCacheIndentLevel' argument being '%s' when calling 'preCacheIndent' of class '%s'.", preCacheIndentLevel, this.getClass().getName()));
 
 		for (int indentLevel = 1; indentLevel <= preCacheIndentLevel; indentLevel++) {
 			if (!this.indentCache.containsKey(indentLevel))

--- a/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * MIT License
- * 
+ *
  * Copyright (c) 2024 fixyldev
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +36,7 @@ public class ComponentFormatter {
 
     private int indentSize;
     private String indent;
-	private Map<Integer, String> indentCache = new HashMap<>();
+	private Map<Integer, String> indentCache = new HashMap<Integer, String>();
 
 	private String componentValue;
 	private List<String> lines;
@@ -112,7 +112,7 @@ public class ComponentFormatter {
 
 		if (this.line.length() != 0)
 			this.lines.add(this.line.toString());
-		
+
 		return this.lines;
     }
 
@@ -131,7 +131,7 @@ public class ComponentFormatter {
 			this.formatInsideOfString();
 		else
 			this.formatOutsideOfString();
-		
+
 		this.onNewLine();
 	}
 
@@ -197,7 +197,7 @@ public class ComponentFormatter {
 	private void onNewLine() {
 		if (this.line.length() != 0)
 			return;
-		
+
 		line.append(this.getIndentFromLevel(this.indentLevel));
 
 		if (this.closingBracket != ' ') {

--- a/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ComponentFormatter {
+	final private static int PRE_CACHE_INDENT_LEVEL = 8;
     final private static int INITIAL_LINES_CAPACITY = 16;
     final private static int INITIAL_LINE_CAPACITY = 16;
 
@@ -49,11 +50,19 @@ public class ComponentFormatter {
 	private boolean inEmptyBrackets;
 	private boolean inString;
 
-    public ComponentFormatter(int indentSize) {
+    public ComponentFormatter(int indentSize, int preCacheIndentLevel) {
+		if (indentSize < 0)
+			throw new IllegalArgumentException();
+
         this.indentSize = indentSize;
 
         this.calculateIndent();
+		this.preCacheIndent(preCacheIndentLevel);
     }
+
+	public ComponentFormatter(int indentSize) {
+		this(indentSize, ComponentFormatter.PRE_CACHE_INDENT_LEVEL);
+	}
 
     private void calculateIndent() {
         StringBuilder indentBuilder = new StringBuilder(this.indentSize);
@@ -63,6 +72,16 @@ public class ComponentFormatter {
 
         this.indent = indentBuilder.toString();
     }
+
+	public void preCacheIndent(int preCacheIndentLevel) {
+		if (preCacheIndentLevel < 0)
+			throw new IllegalArgumentException();
+
+		for (int indentLevel = 1; indentLevel <= preCacheIndentLevel; indentLevel++) {
+			if (!this.indentCache.containsKey(indentLevel))
+				this.indentCache.put(indentLevel, indent.repeat(indentLevel));
+		}
+	}
 
 	private String getIndentFromLevel(int indentLevel) {
 		if (indentLevel <= 0)

--- a/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentFormatter.java
@@ -1,0 +1,130 @@
+/* 
+ * MIT License
+ * 
+ * Copyright (c) 2024 fixyldev
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.fixyl.componentviewer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ComponentFormatter {
+    final private static int INITIAL_LINES_CAPACITY = 16;
+    final private static int INITIAL_LINE_CAPACITY = 16;
+
+    private int indentSize;
+    private String indent;
+	private Map<Integer, String> indentCache = new HashMap<>();
+
+    public ComponentFormatter(int indentSize) {
+        this.indentSize = indentSize;
+
+        this.calculateIndent();
+    }
+
+    private void calculateIndent() {
+        StringBuilder indentBuilder = new StringBuilder(this.indentSize);
+
+        for (int i = 0; i < this.indentSize; i++)
+        indentBuilder.append(' ');
+
+        this.indent = indentBuilder.toString();
+    }
+
+	private String getIndentFromLevel(int indentLevel) {
+		if (indentLevel <= 0)
+			return "";
+
+		if (this.indentCache.containsKey(indentLevel))
+			return this.indentCache.get(indentLevel);
+
+		return this.indentCache.put(indentLevel, indent.repeat(indentLevel));
+	}
+
+    public List<String> format(String componentValue) {
+		List<String> lines = new ArrayList<String>(ComponentFormatter.INITIAL_LINES_CAPACITY);
+		StringBuilder line = new StringBuilder(ComponentFormatter.INITIAL_LINE_CAPACITY);
+		int indent = 0;
+		char closingBracket = ' ';
+		boolean emptyBrackets = false;
+		boolean trim = false;
+		char inString = ' ';
+
+		for (int index = 0; index < componentValue.length(); index++) {
+			char character = componentValue.charAt(index);
+
+			if (emptyBrackets) {
+				line.append(character);
+				emptyBrackets = false;
+				continue;
+			}
+
+			if (trim && character == ' ') 
+				continue;
+			trim = false;
+
+			if (inString == ' ' && (character == ',' || character == ';')) {
+				lines.add(line.toString() + character);
+				line.setLength(0);
+			} else if (inString == ' ' && (character == '[' || character == '{')) {
+				if (index + 1 < componentValue.length() && (componentValue.charAt(index + 1) == ']' || componentValue.charAt(index + 1) == '}')) {
+					line.append(character);
+					emptyBrackets = true;
+					continue;
+				}
+				indent++;
+				lines.add(line.toString() + character);
+				line.setLength(0);
+			} else if (inString == ' ' && (character == ']' || character == '}')) {
+				indent--;
+				closingBracket = character;
+				lines.add(line.toString());
+				line.setLength(0);
+			} else if (character == '"' || character == '\'') {
+				if (inString == ' ')
+					inString = character;
+				else if (character == inString && componentValue.charAt(index - 1) != '\\')
+					inString = ' ';
+				line.append(character);
+			} else
+				line.append(character);
+
+			if (line.length() == 0) {
+				line.append(this.getIndentFromLevel(indent));
+
+				if (closingBracket != ' ') {
+					line.append(closingBracket);
+					closingBracket = ' ';
+				}
+
+				trim = true;
+			}
+		}
+
+		if (line.length() != 0)
+			lines.add(line.toString());
+
+		return lines;
+    }
+}

--- a/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
@@ -41,11 +41,11 @@ import java.util.List;
 
 public class ComponentViewer implements ClientModInitializer {
 	final private static int INITIAL_COMPONENT_LIST_CAPACITY = 16;
-	final private static int INDENTATION = 4;
+	final private static int INDENT_SIZE = 4;
 
 	private static int componentIndex = 0;
 	private static boolean previousAltDown = false;
-	private static ComponentFormatter componentFormatter = new ComponentFormatter(INDENTATION);
+	private static ComponentFormatter componentFormatter = new ComponentFormatter(INDENT_SIZE);
 
 	@Override
 	public void onInitializeClient() {

--- a/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
@@ -41,11 +41,10 @@ import java.util.List;
 
 public class ComponentViewer implements ClientModInitializer {
 	final private static int INITIAL_COMPONENT_LIST_CAPACITY = 16;
-	final private static int INDENT_SIZE = 4;
 
 	private static int componentIndex = 0;
 	private static boolean previousAltDown = false;
-	private static ComponentFormatter componentFormatter = new ComponentFormatter(INDENT_SIZE);
+	private static ComponentFormatter componentFormatter = new ComponentFormatter(ComponentFormatter.DEFAULT_INDENT_SIZE, ComponentFormatter.DEFAULT_PRE_CACHE_INDENT_LEVEL);
 
 	@Override
 	public void onInitializeClient() {
@@ -107,5 +106,8 @@ public class ComponentViewer implements ClientModInitializer {
 		for (String componentValuePart : ComponentViewer.componentFormatter.formatComponentValue(componentValue)) {
 			lines.add((Text)Text.literal(" " + componentValuePart).formatted(Formatting.DARK_GRAY));
 		}
+
+		if (ComponentViewer.componentFormatter.isFormattingError())
+			lines.add((Text)Text.translatable("componentviewer.formatter.error").formatted(Formatting.GRAY));
 	}
 }

--- a/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * MIT License
- * 
+ *
  * Copyright (c) 2024 fixyldev
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
@@ -108,6 +108,6 @@ public class ComponentViewer implements ClientModInitializer {
 		}
 
 		if (ComponentViewer.componentFormatter.isFormattingError())
-			lines.add((Text)Text.translatable("componentviewer.formatter.error").formatted(Formatting.GRAY));
+			lines.add((Text)Text.translatable("componentviewer.tooltips.formatter.error").formatted(Formatting.GRAY));
 	}
 }

--- a/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
+++ b/src/client/java/dev/fixyl/componentviewer/ComponentViewer.java
@@ -104,7 +104,7 @@ public class ComponentViewer implements ClientModInitializer {
 		lines.add((Text)Text.translatable("componentviewer.tooltips.components.value").formatted(Formatting.GRAY));
 
 		String componentValue = componentList.get(ComponentViewer.componentIndex).value().toString();
-		for (String componentValuePart : ComponentViewer.componentFormatter.format(componentValue)) {
+		for (String componentValuePart : ComponentViewer.componentFormatter.formatComponentValue(componentValue)) {
 			lines.add((Text)Text.literal(" " + componentValuePart).formatted(Formatting.DARK_GRAY));
 		}
 	}

--- a/src/main/resources/assets/componentviewer/lang/en_us.json
+++ b/src/main/resources/assets/componentviewer/lang/en_us.json
@@ -1,6 +1,6 @@
 {
-    "componentviewer.formatter.error": "A formatting error occurred: Displaying non-formatted component value.",
     "componentviewer.tooltips.components.empty": "No Components",
     "componentviewer.tooltips.components.header": "Components:",
-    "componentviewer.tooltips.components.value": "Value:"
+    "componentviewer.tooltips.components.value": "Value:",
+    "componentviewer.tooltips.formatter.error": "A formatting error occurred: Displaying non-formatted component value."
 }

--- a/src/main/resources/assets/componentviewer/lang/en_us.json
+++ b/src/main/resources/assets/componentviewer/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+    "componentviewer.formatter.error": "A formatting error occurred: Displaying non-formatted component value.",
     "componentviewer.tooltips.components.empty": "No Components",
     "componentviewer.tooltips.components.header": "Components:",
     "componentviewer.tooltips.components.value": "Value:"


### PR DESCRIPTION
This is a minor patch that made some changes to the component value formatter under the hood.

## Additions
- Added indent caching.
- Added a fallback to non-formatted component values if formatting goes wrong.

## Bug fixes
- Fixed most issues related to formatting of `minecraft:item_name`, `minecraft:custom_name` and `minecraft:lore` components.
  - Characters like `[`, `]`, `"`, `'`, `,` and `;` will no longer break the formatting.

## Known issues
- Certain character combinations with `{` or `}` as item names or item lores might still cause formatting issues.
  - This issue is not resolvable with the current implementation of how "Component Viewer" gathers component value information.